### PR TITLE
V1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #### Automatic security lookups from your clipboard
 
-seclook is a macOS/Swift app that sits in the background and monitors your clipboard, sending any IP, SHA2/MD5 hash, or domain to VirusTotal and AbuseIPDB. If any scanned item has a bad reputation score, you get a notification!
+seclook is a macOS/Swift app that sits in the background and monitors your clipboard, sending any IP, SHA2/MD5 hash, or domain to services like AbuseIPDB, VirusTotal, GreyNoise, and more. If any scanned item has a bad reputation score, you get a notification!
 
 ![seclook UI](images/ui.png)
 
@@ -18,10 +18,13 @@ seclook is a macOS/Swift app that sits in the background and monitors your clipb
 * Send scanned items to the following security lookup services:
   * VirusTotal
   * AbuseIPDB
+  * ThreatFox
+  * GreyNoise
 * Add known-good items to an Ignore List
 * Toggle scanning on/off:
   * Universally using menu bar icon
   * By string type
+  * By integration/lookup service
 
 ## Installation
 
@@ -65,4 +68,8 @@ If you manually copy from a password manager **browser extension**, there is not
 
 ## Thanks
 
-* [VirusTotal](https://www.virustotal.com/) and [AbuseIPDB](https://www.abuseipdb.com/) for their awesome APIs
+* Thanks to these organizations for their awesome APIs:
+  * [VirusTotal](https://www.virustotal.com/)
+  * [AbuseIPDB](https://www.abuseipdb.com/) 
+  * [ThreatFox](https://threatfox.abuse.ch/)
+  * [GreyNoise](https://greynoise.io)

--- a/seclook.xcodeproj/project.pbxproj
+++ b/seclook.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.4;
+				CURRENT_PROJECT_VERSION = 1.5;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"seclook/Preview Content\"";
 				DEVELOPMENT_TEAM = Q48Q39Z6A9;
@@ -491,7 +491,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = ackatz.seclook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -510,7 +510,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.4;
+				CURRENT_PROJECT_VERSION = 1.5;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"seclook/Preview Content\"";
 				DEVELOPMENT_TEAM = Q48Q39Z6A9;
@@ -525,7 +525,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = ackatz.seclook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/seclook/ConfigurationView.swift
+++ b/seclook/ConfigurationView.swift
@@ -3,16 +3,22 @@ import SwiftUI
 struct ConfigurationView: View {
     @State private var abuseIPDBKey: String = ""
     @State private var VirusTotalKey: String = ""
+    @State private var ThreatFoxKey: String = ""
+    @State private var GreyNoiseKey: String = ""
 
     var body: some View {
         Form {
             Section(header: Text("API Keys")) {
                 TextField("AbuseIPDB Key", text: $abuseIPDBKey)
                 TextField("VirusTotal Key", text: $VirusTotalKey)
+                TextField("ThreatFox Key", text: $ThreatFoxKey)
+                TextField("GreyNoise Key", text: $GreyNoiseKey)
 
                 Button("Save") {
                     ConfigManager.shared.setAPIKey(service: "abuseipdb", key: abuseIPDBKey)
                     ConfigManager.shared.setAPIKey(service: "virustotal", key: VirusTotalKey)
+                    ConfigManager.shared.setAPIKey(service: "threatfox", key: ThreatFoxKey)
+                    ConfigManager.shared.setAPIKey(service: "greynoise", key: GreyNoiseKey)
                 }
             }
         }
@@ -20,6 +26,8 @@ struct ConfigurationView: View {
             // Load previously saved keys
             abuseIPDBKey = ConfigManager.shared.getAPIKey(service: "abuseipdb") ?? ""
             VirusTotalKey = ConfigManager.shared.getAPIKey(service: "virustotal") ?? ""
+            ThreatFoxKey = ConfigManager.shared.getAPIKey(service: "threatfox") ?? ""
+            GreyNoiseKey = ConfigManager.shared.getAPIKey(service: "greynoise") ?? ""
         }
     }
 }

--- a/seclook/UserNotifications.swift
+++ b/seclook/UserNotifications.swift
@@ -13,6 +13,12 @@ func postNotification(for item: String, type: String, source: String) {
         case "VirusTotal":
             notificationContent.title = "Security Alert from VirusTotal"
             notificationContent.body = "The \(type) \(item) is potentially malicious according to VirusTotal."
+        case "ThreatFox":
+            notificationContent.title = "Security Alert from ThreatFox"
+            notificationContent.body = "The \(type) \(item) is potentially malicious according to ThreatFox."
+        case "GreyNoise":
+            notificationContent.title = "Security Alert from GreyNoise"
+            notificationContent.body = "The \(type) \(item) is potentially malicious according to GreyNoise."
         default:
             notificationContent.title = "Security Alert"
             notificationContent.body = "The \(type) \(item) is potentially malicious."

--- a/website/static/appcast.xml
+++ b/website/static/appcast.xml
@@ -3,6 +3,27 @@
     <channel>
         <title>seclook</title>
         <item>
+            <title>1.5</title>
+            <pubDate>Fri, 17 May 2024 13:12:26 -0600</pubDate>
+            <sparkle:version>1.5</sparkle:version>
+            <sparkle:shortVersionString>1.5</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+              <description><![CDATA[
+                <b>Note: If you are on <=v1.1, uninstall the app and reinstall with the latest version to enable automatic updates</b>
+                <h2>What's New</h2>
+                <ul>
+                    <li>The app now supports looking up IOCs in ThreatFox! The ThreatFox integration supports IPs, SHA2 and MD5 hashes, and domains.</li>
+                    <li>The app now supports looking up IOCs in GreyNoise! The GreyNoise integration supports IPs.</li>
+                    <li>You can now enable/disable lookups (e.g., VirusTotal, GreyNoise, etc.) within the Settings pane.</li>
+                    <li>There is now a visual confirmation when you save your API keys.</li>
+                    <li>Fixed a bug where the IP regex would miss the last digit in the 4th octet.</li>
+                    <li>Fixed a bug where SHA1 hashes were being incorrectly identified as MD5 hashes due to overlapping regex patterns.</li>
+                    <li>Fixed a bug where settings changes following hitting the "Clear All Settings" button were not persisting after a restart of the app.</li>
+                </ul>
+                ]]></description>
+            <enclosure url="https://github.com/ackatz/seclook/raw/main/Releases/seclook.dmg" length="15020544" type="application/octet-stream" sparkle:edSignature="Vpn9NDFRXMHmzpOoOcYEXxLUAabUORCCPvgSR213/a6eDv/gH5PYdhX/Qmb7QBgbBMdGlsn52wqQRFlH7aBGBQ=="/>
+        </item>
+        <item>
             <title>1.4</title>
             <pubDate>Tue, 09 Jan 2024 16:51:27 -0700</pubDate>
             <sparkle:version>1.4</sparkle:version>


### PR DESCRIPTION
  <h2>What's New</h2>
                <ul>
                    <li>The app now supports looking up IOCs in ThreatFox! The ThreatFox integration supports IPs, SHA2 and MD5 hashes, and domains.</li>
                    <li>The app now supports looking up IOCs in GreyNoise! The GreyNoise integration supports IPs.</li>
                    <li>You can now enable/disable lookups (e.g., VirusTotal, GreyNoise, etc.) within the Settings pane.</li>
                    <li>There is now a visual confirmation when you save your API keys.</li>
                    <li>Fixed a bug where the IP regex would miss the last digit in the 4th octet.</li>
                    <li>Fixed a bug where SHA1 hashes were being incorrectly identified as MD5 hashes due to overlapping regex patterns.</li>
                    <li>Fixed a bug where settings changes following hitting the "Clear All Settings" button were not persisting after a restart of the app.</li>
                </ul>