### PR TITLE
V1.5.1

### DIFF
--- a/seclook.xcodeproj/project.pbxproj
+++ b/seclook.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.5;
+				CURRENT_PROJECT_VERSION = 1.5.1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"seclook/Preview Content\"";
 				DEVELOPMENT_TEAM = Q48Q39Z6A9;
@@ -491,7 +491,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ackatz.seclook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -510,7 +510,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.5;
+				CURRENT_PROJECT_VERSION = 1.5.1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"seclook/Preview Content\"";
 				DEVELOPMENT_TEAM = Q48Q39Z6A9;
@@ -525,7 +525,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.5;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ackatz.seclook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/seclook/ContentView.swift
+++ b/seclook/ContentView.swift
@@ -426,7 +426,6 @@ struct ContentView: View {
         .background(Color(red: 0.11764705882352941, green: 0.11764705882352941, blue: 0.11764705882352941))
         .onAppear {
             // Load the API keys when the view appears
-            print("ContentView loaded. Last scanned item: \(clipboardMonitor.lastScannedItem)")
             abuseIPDBKey = ConfigManager.shared.getAPIKey(service: "abuseipdb") ?? ""
             VirusTotalKey = ConfigManager.shared.getAPIKey(service: "virustotal") ?? ""
             ThreatFoxKey = ConfigManager.shared.getAPIKey(service: "threatfox") ?? ""

--- a/seclook/seclookApp.swift
+++ b/seclook/seclookApp.swift
@@ -95,7 +95,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
      }
     
     func toggleApp() {
-        print("App Active State: \(isAppActive)") // Debug print
         isAppActive.toggle()
         if isAppActive {
             clipboardMonitor.startMonitoring()

--- a/website/static/appcast.xml
+++ b/website/static/appcast.xml
@@ -6,9 +6,9 @@
             <title>1.5</title>
             <pubDate>Fri, 17 May 2024 13:12:26 -0600</pubDate>
             <sparkle:version>1.5</sparkle:version>
-            <sparkle:shortVersionString>1.5</sparkle:shortVersionString>
+            <sparkle:shortVersionString>1.5.1</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-              <description><![CDATA[
+            <description><![CDATA[
                 <b>Note: If you are on <=v1.1, uninstall the app and reinstall with the latest version to enable automatic updates</b>
                 <h2>What's New</h2>
                 <ul>
@@ -20,8 +20,8 @@
                     <li>Fixed a bug where SHA1 hashes were being incorrectly identified as MD5 hashes due to overlapping regex patterns.</li>
                     <li>Fixed a bug where settings changes following hitting the "Clear All Settings" button were not persisting after a restart of the app.</li>
                 </ul>
-                ]]></description>
-            <enclosure url="https://github.com/ackatz/seclook/raw/main/Releases/seclook.dmg" length="15020544" type="application/octet-stream" sparkle:edSignature="Vpn9NDFRXMHmzpOoOcYEXxLUAabUORCCPvgSR213/a6eDv/gH5PYdhX/Qmb7QBgbBMdGlsn52wqQRFlH7aBGBQ=="/>
+            ]]></description>
+            <enclosure url="https://seclook.app/seclook.dmg" length="4641888" type="application/octet-stream" sparkle:edSignature="vnZ2HOsYDVIGf5IhvvYbNU2NT1dcRsnxhsWWKxTmS+z56wu6ON7knwCSR7fncL8K2sHcHVdYaGiq2Jh9s3peAA=="/>
         </item>
         <item>
             <title>1.4</title>
@@ -29,7 +29,7 @@
             <sparkle:version>1.4</sparkle:version>
             <sparkle:shortVersionString>1.4</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-             <description><![CDATA[
+            <description><![CDATA[
                 <b>Note: If you are on <=v1.1, uninstall the app and reinstall with the latest version to enable automatic updates</b>
                 <h2>What's New</h2>
                 <ul>
@@ -54,22 +54,6 @@
                 </ul>
                 ]]></description>
             <enclosure url="https://github.com/ackatz/seclook/raw/main/Releases/seclook.dmg" length="4797536" type="application/octet-stream" sparkle:edSignature="MGFLLyel3VEF0WCcBJTZ6I2CgeTTWi3I/olCpf5K1mwnJMq2kwxZzBtZGNdo5hF0VS9plBjr81BM4lC287YIAw=="/>
-        </item>
-        <item>
-            <title>1.2</title>
-            <pubDate>Sun, 07 Jan 2024 17:23:02 -0700</pubDate>
-            <sparkle:version>1.2</sparkle:version>
-            <sparkle:shortVersionString>1.2</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <description><![CDATA[
-                <h2>What's New</h2>
-                <ul>
-                    <li>Fixed automatic updates</li>
-                    <li>seclook will prompt you with a small window in the top right of your screen before scanning any SHA2 or MD5 hash. This change is to prevent accidental scanning of confidential values.</li>
-                    <li>Fixed an issue where macOS notifications would sometimes be buried in the Notification Center and not immediately display in the top-right of your screen when triggered.</li>
-                </ul>
-                ]]></description>
-            <enclosure url="https://github.com/ackatz/seclook/raw/main/Releases/seclook.dmg" length="4596832" type="application/octet-stream" sparkle:edSignature="9V4Won4QBidsXqEWEfRL0nP2iTLxghue3nHg54eZyY6MDjteOH6IP7kVthMD1Eg52QnFF2BLVzFpSlKC8W8YDw=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
 <h2>What's New</h2>
                <ul>
                    <li>The app now supports looking up IOCs in ThreatFox! The ThreatFox integration supports IPs, SHA2 and MD5 hashes, and domains.</li>
                    <li>The app now supports looking up IOCs in GreyNoise! The GreyNoise integration supports IPs.</li>
                    <li>You can now enable/disable lookups (e.g., VirusTotal, GreyNoise, etc.) within the Settings pane.</li>
                    <li>There is now a visual confirmation when you save your API keys.</li>
                    <li>Fixed a bug where the IP regex would miss the last digit in the 4th octet.</li>
                    <li>Fixed a bug where SHA1 hashes were being incorrectly identified as MD5 hashes due to overlapping regex patterns.</li>
                    <li>Fixed a bug where settings changes following hitting the "Clear All Settings" button were not persisting after a restart of the app.</li>
                </ul>